### PR TITLE
feat: Add marketplace cover image handling to template components

### DIFF
--- a/api/templateApi.ts
+++ b/api/templateApi.ts
@@ -86,6 +86,15 @@ export type MarketplaceTemplateCard = Omit<TemplateDTO, 'content' | 'variables' 
   fonts?: string[];
 };
 
+/** Image affichée catalogue / fiche marketplace (upload publication → API `cover_image_url`). */
+export function marketplaceCoverUrl(t: {
+  cover_image_url?: string;
+  preview?: string;
+}): string | undefined {
+  const u = (t.cover_image_url || t.preview || '').trim();
+  return u || undefined;
+}
+
 export interface PublishToMarketplaceDto {
   templateId: number;
   name: string;

--- a/pages/marketplace.tsx
+++ b/pages/marketplace.tsx
@@ -26,7 +26,7 @@ import {
   IconDiamondFilled,
   IconShoppingCart,
 } from '@tabler/icons-react';
-import { templateApi, MarketplaceTemplateCard } from '@/api/templateApi';
+import { templateApi, MarketplaceTemplateCard, marketplaceCoverUrl } from '@/api/templateApi';
 import { authApi } from '@/api/authApi';
 import CopyTemplateModal from '@/components/marketplace/CopyTemplateModal';
 import PurchaseModal from '@/components/marketplace/PurchaseModal';
@@ -219,89 +219,87 @@ export default function MarketplacePage() {
           </Center>
         ) : (
           <SimpleGrid cols={4} spacing="md">
-            {filtered.map((template) => (
-              <Card
-                key={template.ID}
-                withBorder
-                radius="md"
-                p={0}
-                shadow="xs"
-                style={{ overflow: 'hidden' }}
-              >
-                <Box
-                  style={{
-                    position: 'relative',
-                    height: 180,
-                    backgroundColor: '#e9ecef',
-                    overflow: 'hidden',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
+            {filtered.map((template) => {
+              const coverSrc = marketplaceCoverUrl(template);
+              return (
+                <Card
+                  key={template.ID}
+                  withBorder
+                  radius="md"
+                  p={0}
+                  shadow="xs"
+                  style={{ overflow: 'hidden' }}
                 >
-                  {template.preview?.trim() ? (
-                    <Image
-                      src={template.preview.trim()}
-                      alt={template.name || ''}
-                      h={180}
-                      fit="cover"
-                    />
-                  ) : (
-                    <Text size="sm" c="dimmed" ta="center" px="md">
-                      {template.description || 'Aperçu non disponible'}
-                    </Text>
-                  )}
-                  {(template.price ?? 0) > 0 && (
-                    <Badge
-                      style={{ position: 'absolute', top: 8, left: 8 }}
-                      color="yellow"
-                      variant="filled"
-                      size="xs"
-                      fw={700}
-                    >
-                      PREMIUM
-                    </Badge>
-                  )}
-                </Box>
+                  <Box
+                    style={{
+                      position: 'relative',
+                      height: 180,
+                      backgroundColor: '#e9ecef',
+                      overflow: 'hidden',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    {coverSrc ? (
+                      <Image src={coverSrc} alt={template.name || ''} h={180} fit="cover" />
+                    ) : (
+                      <Text size="sm" c="dimmed" ta="center" px="md">
+                        {template.description || 'Aperçu non disponible'}
+                      </Text>
+                    )}
+                    {(template.price ?? 0) > 0 && (
+                      <Badge
+                        style={{ position: 'absolute', top: 8, left: 8 }}
+                        color="yellow"
+                        variant="filled"
+                        size="xs"
+                        fw={700}
+                      >
+                        PREMIUM
+                      </Badge>
+                    )}
+                  </Box>
 
-                <Box p="md">
-                  <Group justify="space-between" align="flex-start" mb={4}>
-                    <Text fw={700} size="sm" lineClamp={1} style={{ flex: 1 }}>
-                      {template.name}
+                  <Box p="md">
+                    <Group justify="space-between" align="flex-start" mb={4}>
+                      <Text fw={700} size="sm" lineClamp={1} style={{ flex: 1 }}>
+                        {template.name}
+                      </Text>
+                      <Text fw={700} size="sm" c="blue">
+                        {(template.price ?? 0) === 0
+                          ? 'Free'
+                          : `$${((template.price ?? 0) / 100).toFixed(0)}`}
+                      </Text>
+                    </Group>
+                    <Text size="xs" c="dimmed" lineClamp={2} mb="md">
+                      {template.description || 'No description available.'}
                     </Text>
-                    <Text fw={700} size="sm" c="blue">
-                      {(template.price ?? 0) === 0
-                        ? 'Free'
-                        : `$${((template.price ?? 0) / 100).toFixed(0)}`}
+                    <Text size="xs" c="dimmed" mb="sm">
+                      By {template.author_user_name || 'Unknown'}
                     </Text>
-                  </Group>
-                  <Text size="xs" c="dimmed" lineClamp={2} mb="md">
-                    {template.description || 'No description available.'}
-                  </Text>
-                  <Text size="xs" c="dimmed" mb="sm">
-                    By {template.author_user_name || 'Unknown'}
-                  </Text>
-                  <Group gap={6}>
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      flex={1}
-                      onClick={() => router.push(`/marketplace/templates/${template.ID}`)}
-                    >
-                      Detail
-                    </Button>
-                    <Button
-                      size="xs"
-                      flex={1}
-                      leftSection={<IconShoppingCart size={12} />}
-                      onClick={() => handleBuyNow(template)}
-                    >
-                      {(template.price ?? 0) === 0 ? 'Get Free' : 'Buy Now'}
-                    </Button>
-                  </Group>
-                </Box>
-              </Card>
-            ))}
+                    <Group gap={6}>
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        flex={1}
+                        onClick={() => router.push(`/marketplace/templates/${template.ID}`)}
+                      >
+                        Detail
+                      </Button>
+                      <Button
+                        size="xs"
+                        flex={1}
+                        leftSection={<IconShoppingCart size={12} />}
+                        onClick={() => handleBuyNow(template)}
+                      >
+                        {(template.price ?? 0) === 0 ? 'Get Free' : 'Buy Now'}
+                      </Button>
+                    </Group>
+                  </Box>
+                </Card>
+              );
+            })}
           </SimpleGrid>
         )}
 

--- a/pages/marketplace/templates/[id].tsx
+++ b/pages/marketplace/templates/[id].tsx
@@ -19,7 +19,7 @@ import {
   Badge,
 } from '@mantine/core';
 import { IconCheck, IconChevronLeft, IconShoppingCart, IconDownload } from '@tabler/icons-react';
-import { templateApi, TemplateDTO } from '@/api/templateApi';
+import { templateApi, TemplateDTO, marketplaceCoverUrl } from '@/api/templateApi';
 import Preview from '@/components/Preview';
 import CopyTemplateModal from '@/components/marketplace/CopyTemplateModal';
 import PurchaseModal from '@/components/marketplace/PurchaseModal';
@@ -74,6 +74,8 @@ export default function MarketplaceTemplateDetail() {
     }
   };
 
+  const coverSrc = marketplaceCoverUrl(template);
+
   return (
     <Box style={{ minHeight: '100vh', backgroundColor: '#f8f9fa' }}>
       {/* Header */}
@@ -97,9 +99,27 @@ export default function MarketplaceTemplateDetail() {
           {/* Left Column */}
           <Grid.Col span={8}>
             <Stack gap="xl">
-              {template.preview?.trim() ? (
-                <Box style={{ borderRadius: 8, overflow: 'hidden', border: '1px solid #e9ecef' }}>
-                  <Image src={template.preview.trim()} alt={template.name || ''} radius="md" />
+              {coverSrc ? (
+                <Box
+                  style={{
+                    borderRadius: 8,
+                    overflow: 'hidden',
+                    border: '1px solid #e9ecef',
+                    height: 520,
+                    backgroundColor: '#f8f9fa',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Image
+                    src={coverSrc}
+                    alt={template.name || ''}
+                    radius="md"
+                    fit="contain"
+                    w="100%"
+                    h="100%"
+                  />
                 </Box>
               ) : (
                 <Box

--- a/pages/marketplace/templates/index.tsx
+++ b/pages/marketplace/templates/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mantine/core';
 import { IconShoppingCart } from '@tabler/icons-react';
 import { RequestStatus } from '@/api/request-status.enum';
-import { templateApi, MarketplaceTemplateCard } from '@/api/templateApi';
+import { templateApi, MarketplaceTemplateCard, marketplaceCoverUrl } from '@/api/templateApi';
 
 interface MarketplaceTemplate extends MarketplaceTemplateCard {
   id: string;
@@ -54,7 +54,7 @@ export default function MarketplaceTemplates() {
           name: template.name || 'Untitled Template',
           description: template.description || '',
           price: template.price || 0,
-          preview: template.preview || '',
+          preview: marketplaceCoverUrl(template) ?? '',
           rating: template.rating || 0,
           reviewCount: template.reviewCount || 0,
           author: {


### PR DESCRIPTION
- Introduced `marketplaceCoverUrl` function to retrieve cover image URLs for templates.
- Updated MarketplacePage to display cover images using the new function.
- Enhanced template detail view to utilize cover images instead of previews.
- Adjusted template listing to ensure consistent image handling across components.