### PR TITLE
Add "Open in new tab" functionality to TemplateItem component

### DIFF
--- a/components/TemplateItem/TemplateItem.tsx
+++ b/components/TemplateItem/TemplateItem.tsx
@@ -7,6 +7,7 @@ import {
   IconDots,
   IconTrash,
   IconEdit,
+  IconExternalLink,
   IconPencil,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
@@ -43,6 +44,11 @@ export default function TemplateItem({
 
   const navigateToTemplate = () => {
     router.push(`/dashboard/templates/create/${uuid}`);
+  };
+
+  const openInNewTab = () => {
+    if (!uuid) return;
+    window.open(`/dashboard/templates/create/${uuid}`, '_blank', 'noopener,noreferrer');
   };
 
   const deleteTemplate = async () => {
@@ -94,6 +100,15 @@ export default function TemplateItem({
               }}
             >
               Edit
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<IconExternalLink size={14} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                openInNewTab();
+              }}
+            >
+              Open in new tab
             </Menu.Item>
             <Menu.Item
               leftSection={<IconPencil size={14} />}


### PR DESCRIPTION
This commit introduces a new feature in the TemplateItem component that allows users to open a template in a new tab. Key changes include:

- Added an `IconExternalLink` import for the new menu item.
- Implemented the `openInNewTab` function to handle the new tab opening logic.
- Included a new menu item in the TemplateItem dropdown for the "Open in new tab" action.

These enhancements aim to improve user experience by providing quick access to templates in separate tabs.